### PR TITLE
feat: add local development and debug configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ yarn install
 docker compose up --wait
 ```
 
+## Bring up services (with local versions of server and client)
+
+```
+SERVER_DIR="../enhanced-preprints-server" CLIENT_DIR="../enhanced-preprints-client" docker compose -f docker-compose.yaml -f docker-compose.localserver.yaml -f docker-compose.localclient.yaml up
+```
+
 Alternatively run `docker compose up` and wait for the services to come up.
 
 ### List of services
@@ -62,6 +68,12 @@ To run tests on your host machine:
 yarn test
 ```
 
+To run and debug tests on your host machine:
+
+```
+yarn test:debug
+```
+
 To run a single test on your host machine:
 
 ```
@@ -79,7 +91,6 @@ To run the linter:
 ```
 yarn lint
 ```
-
 
 ## Preparing new tests
 

--- a/docker-compose.localclient.yaml
+++ b/docker-compose.localclient.yaml
@@ -1,0 +1,26 @@
+services:
+  yarn:
+    build:
+      context: ${CLIENT_DIR}
+      target: dev
+    command: yarn
+    volumes:
+      - ${CLIENT_DIR}/:/opt/epp-client/
+      - node_modules:/opt/epp-client/node_modules
+  client:
+    image: client-local
+    build:
+      context: ${CLIENT_DIR}
+      dockerfile: Dockerfile
+      target: dev
+    depends_on:
+      yarn:
+        condition: service_completed_successfully
+    ports:
+      - 3001:3000
+    volumes:
+      - ${CLIENT_DIR}/:/opt/epp-client/
+      - node_modules:/opt/epp-client/node_modules
+
+volumes:
+  node_modules:

--- a/docker-compose.localserver.yaml
+++ b/docker-compose.localserver.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    image: api-local
+    build:
+      context: ${SERVER_DIR}
+      dockerfile: Dockerfile
+      target: dev
+    volumes:
+      - ${SERVER_DIR}/src:/opt/epp/src

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "test": "playwright test --workers 5",
+    "test:debug": "playwright test --debug",
     "test:docker": "docker compose -f docker-compose.yaml -f docker-compose.test.yaml run --build test",
     "lint": "eslint --ext .ts,.json tests/ wiremock/",
     "lint:fix": "eslint --fix --ext .ts tests/"

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -31,23 +31,25 @@ test.describe('progress a manuscript through the manifestations', () => {
 
   test('successful progression of manuscript', async ({ page }) => {
     const response1 = await page.goto(`${config.client_url}/previews/progress-msid`);
-    expect(response1?.status()).toBeGreaterThan(400);
+    expect(response1?.status()).toBe(404);
+    const response2 = await page.goto(`${config.client_url}/reviewed-preprints/progress-msid`);
+    expect(response2?.status()).toBe(404);
 
     await changeState(name, 'Preview');
 
     // Wait for preview to become available.
     await expect(async () => {
-      const response2 = await page.goto(`${config.client_url}/previews/progress-msid`);
-      expect(response2?.status()).toBe(200);
+      const response3 = await page.goto(`${config.client_url}/previews/progress-msid`);
+      expect(response3?.status()).toBe(200);
     }).toPass();
-    const response3 = await page.goto(`${config.client_url}/reviewed-preprints/progress-msid`);
-    expect(response3?.status()).toBe(404);
+    const response4 = await page.goto(`${config.client_url}/reviewed-preprints/progress-msid`);
+    expect(response4?.status()).toBe(404);
 
     await changeState(name, 'Published');
 
     await expect(async () => {
-      const response4 = await page.goto(`${config.client_url}/reviewed-preprints/progress-msid`);
-      expect(response4?.status()).toBe(200);
+      const response5 = await page.goto(`${config.client_url}/reviewed-preprints/progress-msid`);
+      expect(response5?.status()).toBe(200);
     }).toPass();
   });
 });


### PR DESCRIPTION
Update README.md with instructions for bringing up services using local versions of server and client. Add yarn debug test command to package.json. Introduce new docker-compose files for local client and server setup. Adjust `progress.spec.ts` test to better handle response status assertions.

This will not pass until we get the following 2 PR's in and update the images:
- https://github.com/elifesciences/enhanced-preprints-server/pull/840
- https://github.com/elifesciences/enhanced-preprints-client/pull/1192