### PR TITLE
feat: add local worker service in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ docker compose up --wait
 
 Alternatively run `docker compose up` and wait for the services to come up.
 
-## Bring up services with local versions of server and client
+## Bring up services with local versions of server, client and worker
 
 ```
-SERVER_DIR="../enhanced-preprints-server" CLIENT_DIR="../enhanced-preprints-client" docker compose -f docker-compose.yaml -f docker-compose.localserver.yaml -f docker-compose.localclient.yaml up
+SERVER_DIR="../enhanced-preprints-server" CLIENT_DIR="../enhanced-preprints-client" IMPORT_DIR="../enhanced-preprints-import" docker compose -f docker-compose.yaml -f docker-compose.localserver.yaml -f docker-compose.localclient.yaml -f docker-compose.localworker.yaml up
 ```
 
 ### List of services

--- a/docker-compose.localworker.yaml
+++ b/docker-compose.localworker.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    image: worker-local
+    build:
+      context: ${IMPORT_DIR}
+      dockerfile: Dockerfile
+      target: worker
+    volumes:
+      - ${IMPORT_DIR}/src:/app/src


### PR DESCRIPTION
Updated README.md with instructions to bring up services with local versions of server, client, and worker using docker compose. Added a new docker-compose.localworker.yaml file for setting up the local worker service.

@scottaubrey @will-byrne would love to pair/mob with you on this one as I'm having issues. This would be a nice add to improve dev experience.