### PR TITLE
Move all pollDocMapIndex workflows to scheduled workflows

### DIFF
--- a/tests/continuum-api.spec.ts
+++ b/tests/continuum-api.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('continuum api', () => {
@@ -16,12 +16,12 @@ test.describe('continuum api', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
     ]);

--- a/tests/future-publish.spec.ts
+++ b/tests/future-publish.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('reviewed preprint', () => {
@@ -16,12 +16,12 @@ test.describe('reviewed preprint', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal, '10  minutes');
+    await startScheduledImportWorkflow(name, workflowId, temporal, '10  minutes');
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
     ]);

--- a/tests/preview.spec.ts
+++ b/tests/preview.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('preview preprint', () => {
@@ -16,12 +16,12 @@ test.describe('preview preprint', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
     ]);

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 import { changeState, resetState } from '../utils/wiremock';
 
@@ -17,12 +17,12 @@ test.describe('progress a manuscript through the manifestations', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/progress-msidv1`),
       axios.delete(`${config.api_url}/preprints/progress-msidv2`),
       deleteS3EppFolder(minioClient, 'progress-msid'),

--- a/tests/reviews.spec.ts
+++ b/tests/reviews.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('reviewed preprint', () => {
@@ -16,12 +16,12 @@ test.describe('reviewed preprint', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
     ]);

--- a/tests/revised.spec.ts
+++ b/tests/revised.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('revised preprint', () => {
@@ -19,12 +19,12 @@ test.describe('revised preprint', () => {
     temporal = await createTemporalClient();
     workflowId = generateWorkflowId(name);
 
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       axios.delete(`${config.api_url}/preprints/${name}-msidv2`),

--- a/tests/unpublish.spec.ts
+++ b/tests/unpublish.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 import { changeState, resetState } from '../utils/wiremock';
 
@@ -17,12 +17,12 @@ test.describe('unpublished preprint', () => {
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       resetState(name),

--- a/tests/versions.spec.ts
+++ b/tests/versions.spec.ts
@@ -5,7 +5,7 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startWorkflow, stopWorkflow,
+  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('versions', () => {
@@ -19,12 +19,12 @@ test.describe('versions', () => {
     temporal = await createTemporalClient();
     workflowId = generateWorkflowId(name);
 
-    await startWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, workflowId, temporal);
   });
 
   test.afterEach(async () => {
     const tearDowns: Promise<any>[] = [
-      stopWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(workflowId, temporal),
       deleteS3EppFolder(minioClient, `${name}-msid`),
     ];
 


### PR DESCRIPTION
This maps how this is used in deployed environments, and allows us to remove `pollDocMapIndex` workflow from import