### PR TITLE
Change the expectation in this test to allow concurrent tests to publish at the same time

### DIFF
--- a/tests/continuum-api.spec.ts
+++ b/tests/continuum-api.spec.ts
@@ -37,7 +37,7 @@ test.describe('continuum api', () => {
       expect(item.ok()).toBeTruthy();
     }).toPass();
 
-    const list = await request.get(`${config.client_url}/api/reviewed-preprints`, {
+    const listResponse = await request.get(`${config.client_url}/api/reviewed-preprints`, {
       headers: {
         Accept: 'application/vnd.elife.reviewed-preprint-list+json; version=1',
       },
@@ -66,10 +66,13 @@ test.describe('continuum api', () => {
       ],
     };
 
-    expect(list.ok()).toBeTruthy();
-    expect(await list.json()).toStrictEqual({ total: 1, items: [expectSnippet] });
+    expect(listResponse.ok()).toBeTruthy();
+    const list = await listResponse.json();
+    // this isn't isolated enough to work
+    // expect(list).toStrictEqual({ total: 1, items: [expectSnippet] });
+    expect(list.items).toContainEqual(expectSnippet);
 
-    const listHeaders = list.headers();
+    const listHeaders = listResponse.headers();
     expect(listHeaders['content-type']).toBe('application/vnd.elife.reviewed-preprint-list+json; version=1');
     expect(listHeaders['cache-control']).toBe('max-age=300, public, stale-if-error=86400, stale-while-revalidate=300');
 


### PR DESCRIPTION
This test has registered quite a few failures in the last few days. Usually manifested as another entry turns up in the response. 

e.g. https://github.com/elifesciences/enhanced-preprints-e2e/actions/runs/6864191568/job/18665415789?pr=270

This looks like when multiple tests run and publish another manuscript at the same time, but this test expects no other published manuscript to be in the response.
