### PR TITLE
feat: rename workflowId to scheduleId in all test files and utils

### DIFF
--- a/tests/continuum-api.spec.ts
+++ b/tests/continuum-api.spec.ts
@@ -5,23 +5,23 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('continuum api', () => {
   let temporal: Client;
   const name = 'continuum-api';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),

--- a/tests/future-publish.spec.ts
+++ b/tests/future-publish.spec.ts
@@ -5,23 +5,23 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('reviewed preprint', () => {
   let temporal: Client;
   const name = 'future-publish';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal, '10  minutes');
+    await startScheduledImportWorkflow(name, scheduleId, temporal, '10  minutes');
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),

--- a/tests/preview.spec.ts
+++ b/tests/preview.spec.ts
@@ -5,23 +5,23 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('preview preprint', () => {
   let temporal: Client;
   const name = 'preview';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -5,24 +5,24 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 import { changeState, resetState } from '../utils/wiremock';
 
 test.describe('progress a manuscript through the manifestations', () => {
   let temporal: Client;
   const name = 'progress';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/progress-msidv1`),
       axios.delete(`${config.api_url}/preprints/progress-msidv2`),
       deleteS3EppFolder(minioClient, 'progress-msid'),

--- a/tests/reviews.spec.ts
+++ b/tests/reviews.spec.ts
@@ -5,23 +5,23 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('reviewed preprint', () => {
   let temporal: Client;
   const name = 'reviews';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),

--- a/tests/revised.spec.ts
+++ b/tests/revised.spec.ts
@@ -5,26 +5,26 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('revised preprint', () => {
   const minioClient = createS3Client();
   let temporal: Client;
   const name = 'revised';
-  let workflowId: string;
+  let scheduleId: string;
 
   // eslint-disable-next-line no-empty-pattern
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    workflowId = generateWorkflowId(name);
+    scheduleId = generateScheduleId(name);
 
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),

--- a/tests/unpublish.spec.ts
+++ b/tests/unpublish.spec.ts
@@ -5,24 +5,24 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 import { changeState, resetState } from '../utils/wiremock';
 
 test.describe('unpublished preprint', () => {
   let temporal: Client;
   const name = 'unpublish';
-  const workflowId = generateWorkflowId(name);
+  const scheduleId = generateScheduleId(name);
   const minioClient = createS3Client();
 
   test.beforeAll(async () => {
     temporal = await createTemporalClient();
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterAll(async () => {
     await Promise.all([
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       axios.delete(`${config.api_url}/preprints/${name}-msidv1`),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),

--- a/tests/versions.spec.ts
+++ b/tests/versions.spec.ts
@@ -5,26 +5,26 @@ import { createS3Client } from '../utils/create-s3-client';
 import { deleteS3EppFolder } from '../utils/delete-s3-epp-folder';
 import { config } from '../utils/config';
 import {
-  createTemporalClient, generateWorkflowId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
+  createTemporalClient, generateScheduleId, startScheduledImportWorkflow, stopScheduledImportWorkflow,
 } from '../utils/temporal';
 
 test.describe('versions', () => {
   const minioClient = createS3Client();
   let temporal: Client;
   const name = 'versions';
-  let workflowId: string;
+  let scheduleId: string;
 
   // eslint-disable-next-line no-empty-pattern
   test.beforeEach(async () => {
     temporal = await createTemporalClient();
-    workflowId = generateWorkflowId(name);
+    scheduleId = generateScheduleId(name);
 
-    await startScheduledImportWorkflow(name, workflowId, temporal);
+    await startScheduledImportWorkflow(name, scheduleId, temporal);
   });
 
   test.afterEach(async () => {
     const tearDowns: Promise<any>[] = [
-      stopScheduledImportWorkflow(workflowId, temporal),
+      stopScheduledImportWorkflow(scheduleId, temporal),
       deleteS3EppFolder(minioClient, `${name}-msid`),
       deleteS3EppFolder(minioClient, `state/${name}`),
     ];

--- a/utils/temporal.ts
+++ b/utils/temporal.ts
@@ -1,7 +1,7 @@
 import { Client, Connection, ScheduleOverlapPolicy } from '@temporalio/client';
 import { config } from './config';
 
-export const generateWorkflowId = (prefix: string): string => {
+export const generateScheduleId = (prefix: string): string => {
   if (prefix.trim().length === 0) {
     throw Error('Empty prefix');
   }
@@ -14,9 +14,9 @@ export const createTemporalClient = async () => {
   return new Client({ connection });
 };
 
-export const startScheduledImportWorkflow = async (testName: string, workflowId: string, client: Client, duration: any = '1 minute') => {
+export const startScheduledImportWorkflow = async (testName: string, scheduleId: string, client: Client, duration: any = '1 minute') => {
   const handle = await client.schedule.create({
-    scheduleId: workflowId,
+    scheduleId: scheduleId,
     spec: {
       intervals: [{ every: duration }],
     },
@@ -36,8 +36,8 @@ export const startScheduledImportWorkflow = async (testName: string, workflowId:
   return handle;
 };
 
-export const stopScheduledImportWorkflow = async (workflowId: string, client: Client) => {
-  const handle = client.schedule.getHandle(workflowId);
+export const stopScheduledImportWorkflow = async (scheduleId: string, client: Client) => {
+  const handle = client.schedule.getHandle(scheduleId);
   await handle.delete();
   return handle;
 };


### PR DESCRIPTION
Renamed 'workflowId' to 'scheduleId' across all test files and utility functions in 'temporal.ts'. This change includes the renaming of the 'generateWorkflowId' function to 'generateScheduleId'. Also, updated all calls to the 'startScheduledImportWorkflow' and 'stopScheduledImportWorkflow' functions to use the new 'scheduleId'.