### PR TITLE
Use Yaml anchors instead of docker compose extends

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -178,7 +178,7 @@ services:
     ports:
       - 3005:3000
 
-  worker:
+  worker: &worker-config
     image: ghcr.io/elifesciences/enhanced-preprints-import-worker:master-ffcf8557-20240315.0509
     depends_on:
       createbucket:
@@ -232,8 +232,7 @@ services:
       start_period: 2s
 
   worker-import-docmaps:
-    extends:
-      service: worker
+    <<: *worker-config
     environment:
       TEMPORAL_TASK_QUEUE: import-docmaps
     healthcheck:


### PR DESCRIPTION
This is because newer docker compose enforces this restriction: https://github.com/compose-spec/compose-spec/blob/master/05-services.md#restrictions and throws this error:

```
> docker compose up 
service "worker" can't be used with `extends` as it declare `depends_on`

> docker compose version
Docker Compose version v2.24.6-desktop.1
```