### PR TITLE
Update api healthcheck test in docker-compose [elifesciences/enhanced-preprints-issues#1114]

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,7 +119,7 @@ services:
   api:
     image: ghcr.io/elifesciences/enhanced-preprints-server:master-84cabe53-20240611.0154
     healthcheck:
-      test: sh -c 'apk add curl; curl http://api:3000/'
+      test: sh -c 'apk add curl; curl http://localhost:3000/'
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Changed the endpoint URL in the healthcheck test for the 'api' service in the docker-compose file from 'http://api:3000/' to 'http://localhost:3000/'.